### PR TITLE
link for user to post anonymous feedback

### DIFF
--- a/web/controllers/github_api/http_client.ex
+++ b/web/controllers/github_api/http_client.ex
@@ -65,6 +65,7 @@ defmodule Dwylbot.GithubAPI.HTTPClient do
 
         Any questions, complaints, feedback, contributions?
         [![Discuss](https://img.shields.io/badge/discuss-with%20us-brightgreen.svg?style=flat)](https://github.com/dwyl/dwylbot/issues "Discuss your ideas/suggestions with us!")
+        If you prefer, you can also send us anonymous feedback: https://dwyl-feedback.herokuapp.com/feedback/new
         """
         message = comment <> feedback
         url


### PR DESCRIPTION
ref: https://github.com/dwyl/dwylbot/issues/94#issuecomment-309503386

This PR add the link to the feedback app, to let user send us anonymous feedback if they prefer not using the issues on Github