### PR TITLE
resolve bugs on merge-conflict rule

### DIFF
--- a/test/fixtures/issue_pr.json
+++ b/test/fixtures/issue_pr.json
@@ -28,13 +28,6 @@
     "site_admin": false
   },
   "labels": [
-    {
-      "id": 624855447,
-      "url": "https://api.github.com/repos/SimonLab/github_app/labels/merge-conflicts",
-      "name": "merge-conflicts",
-      "color": "e74c3c",
-      "default": false
-    }
   ],
   "state": "open",
   "locked": false,

--- a/web/controllers/rules/pr/merge_conflict.ex
+++ b/web/controllers/rules/pr/merge_conflict.ex
@@ -14,7 +14,8 @@ defmodule Dwylbot.Rules.PR.MergeConflict do
 
     actions = payload
     |> Enum.filter(fn(pr) ->
-      !pr["pull_request"]["mergeable"]
+      pr["pull_request"]["mergeable"] == false
+      && !Helpers.label_member?(pr["issue"]["labels"], "merge-conflicts")
     end)
     |> Enum.map(fn(pr) ->
       [
@@ -42,7 +43,7 @@ defmodule Dwylbot.Rules.PR.MergeConflict do
       %{
         error_type: "pr_merge_conflict",
         actions: actions,
-        wait: Helpers.wait(Mix.env, 10_000, 1000, 1),
+        wait: Helpers.wait(Mix.env, 40_000, 1000, 1),
         verify: false
       }
     else


### PR DESCRIPTION
ref #103, #102

Check for pr has the property ```mergeable``` to false instead of checking that the value is not false (issue when the value is null)
Wait a bit longer for Github to update the status of the PR