### PR TITLE
Assignee in progress

### DIFF
--- a/web/controllers/rules/issue/inprogress.ex
+++ b/web/controllers/rules/issue/inprogress.ex
@@ -22,6 +22,10 @@ defmodule Dwylbot.Rules.Issue.Inprogress do
           %{
             comment: payload["sender"] && error_message(payload["sender"]["login"]),
             url: payload["issue"]["comments_url"]
+          },
+          %{
+            add_assignees: [payload["sender"]["login"]],
+            url: "#{payload["issue"]["url"]}/assignees"
           }
         ],
         wait: Helpers.wait(Mix.env, 30_000, 1000, 1),

--- a/web/controllers/rules/issue/inprogress.ex
+++ b/web/controllers/rules/issue/inprogress.ex
@@ -39,7 +39,7 @@ defmodule Dwylbot.Rules.Issue.Inprogress do
   defp error_message(login) do
     """
     @#{login} the `in-progress` label has been added to this issue **without an Assignee**.
-    Please assign a user to this issue before applying the `in-progress label`.
+    dwylbot has automatically assigned you.
     """
   end
 end


### PR DESCRIPTION
- Assigns sender to in-progress issue when it's lacking an assignee. Changes the dwylbot message to inform the user this has been done. #7 