### PR TITLE
check in-progress when reviewer added

### DIFF
--- a/test/fixtures/pr_no_assignee.json
+++ b/test/fixtures/pr_no_assignee.json
@@ -78,7 +78,25 @@
       }
     ],
     "requested_reviewers": [
-
+      {
+        "login": "dwylbot",
+        "id": 24862484,
+        "avatar_url": "https://avatars3.githubusercontent.com/u/24862484?v=3",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/dwylbot",
+        "html_url": "https://github.com/dwylbot",
+        "followers_url": "https://api.github.com/users/dwylbot/followers",
+        "following_url": "https://api.github.com/users/dwylbot/following{/other_user}",
+        "gists_url": "https://api.github.com/users/dwylbot/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/dwylbot/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/dwylbot/subscriptions",
+        "organizations_url": "https://api.github.com/users/dwylbot/orgs",
+        "repos_url": "https://api.github.com/users/dwylbot/repos",
+        "events_url": "https://api.github.com/users/dwylbot/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/dwylbot/received_events",
+        "type": "User",
+        "site_admin": false
+      }
     ],
     "milestone": null,
     "commits_url": "https://api.github.com/repos/SimonLab/github_app/pulls/24/commits",

--- a/web/controllers/rules/pr/awaiting_review.ex
+++ b/web/controllers/rules/pr/awaiting_review.ex
@@ -1,6 +1,6 @@
 defmodule Dwylbot.Rules.PR.AwaitingReview do
   @moduledoc """
-  add awaiting-review if the
+  add awaiting-review if a reviewer has been added to the PR
   """
   alias Dwylbot.Rules.Helpers
   @github_api Application.get_env(:dwylbot, :github_api)
@@ -9,22 +9,30 @@ defmodule Dwylbot.Rules.PR.AwaitingReview do
     (payload["action"] == "review_requested")
   end
 
-  def check(payload, get_data?, token) do
-    payload = (get_data? && @github_api.get_data(token, payload, "pull_request"))
-              || payload
-    reviewers = payload["pull_request"]["requested_reviewers"]
+  def check(payload, _get_data?, token) do
+    payload = @github_api.get_data(token, payload, "issue_from_pr")
+
+    reviewers = payload["pull_request"]["pull_request"]["requested_reviewers"]
     |> Enum.map(&(&1["login"]))
-    unless Enum.empty? payload["pull_request"]["requested_reviewers"] do
+
+    in_progress = payload["issue"]["labels"]
+    |> Helpers.label_member?("in-progress")
+
+    if (!Enum.empty?(reviewers) && !in_progress) do
       %{
         error_type: "pr_awaiting_review",
         actions: [
           %{
             add_labels: ["awaiting-review"],
-            url: "#{payload["pull_request"]["issue_url"]}/labels"
+            url: "#{payload["issue"]["url"]}/labels"
           },
           %{
             add_assignees: reviewers,
-            url: "#{payload["pull_request"]["issue_url"]}/assignees"
+            url: "#{payload["issue"]["url"]}/assignees"
+          },
+          %{
+            comment: error_message(payload["issue"]["user"]["login"]),
+            url: payload["issue"]["comments_url"]
           },
         ],
         wait: Helpers.wait(Mix.env, 30_000, 1000, 1),
@@ -33,6 +41,14 @@ defmodule Dwylbot.Rules.PR.AwaitingReview do
     else
       nil
     end
+  end
+
+  defp error_message(login) do
+    """
+    @#{login}, a reviewer has been added to the pull request.
+    The pull request looks ready for review (no "in-progress" label).
+    So the reviewer has been added as an assignee and the "awaiting-reivew" label as been added to.
+    """
   end
 
 end


### PR DESCRIPTION
ref: #123

When a reviewer is added, check if the in-progress label exists on the PR. If not we assign the reviewer to the PR, add the "awaiting-review" label and add a comment to explain the changes on the PR