### PR TITLE
add procfile for heroku to use phx.server

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: MIX_ENV=prod mix phx.server


### PR DESCRIPTION
ref: #178
use ```mix phx.server``` instead of ```mix phoenix.server``` to start the server on Heroku